### PR TITLE
gemspec: List files explicitly, drop executables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.5', '2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v1

--- a/faraday-rashify.gemspec
+++ b/faraday-rashify.gemspec
@@ -17,13 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = 'https://github.com/lostisland/faraday-rashify'
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-rashify'
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt']
   spec.require_paths = ['lib']
   spec.add_runtime_dependency 'faraday'
 end

--- a/faraday-rashify.gemspec
+++ b/faraday-rashify.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'This middleware was extracted from faraday_middleware.'
   spec.homepage      = 'https://github.com/lostisland/faraday-rashify'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   spec.metadata['homepage_uri'] = 'https://github.com/lostisland/faraday-rashify'
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-rashify'


### PR DESCRIPTION
## Description

This gem exposes no executables: we can skip defining that.

By being explicit about which files are to be globbed into the gem, we can also avoid an unnecessary shell-out.

- gemspec: Require Ruby 2.5+
- CI: drop 2.4, add 3.0
